### PR TITLE
Fix mecenv

### DIFF
--- a/mecenv
+++ b/mecenv
@@ -2,7 +2,7 @@
 # Source this to load the full environment that hutch python uses
 
 # edit this line only
-export CONDA_ENVNAME="pcds-2.0.1"
+export CONDA_ENVNAME="pcds-3.2.0"
 export CONDA_BASE="/reg/g/pcds/pyps/conda/py36"
 export HUTCH="mec"
 
@@ -12,7 +12,6 @@ unset LD_LIBRARY_PATH
 source "${CONDA_BASE}/etc/profile.d/conda.sh"
 conda activate "${CONDA_ENVNAME}"
 HERE=`dirname $(readlink -f $0)`
-export PYTHONPATH="${HERE}:${HERE}/dev/devpath:/reg/neh/home/tjohnson/trunk/hutch-python/forks/pcdsdevices:/reg/neh/home/tjohnson/trunk/hutch-python/forks/pcdsdaq"
-#export PYTHONPATH="${HERE}:${HERE}/dev/devpath:/reg/neh/home/tjohnson/trunk/hutch-python/forks/pcdsdevices"
+export PYTHONPATH="${HERE}:${HERE}/dev/devpath:/reg/neh/home/tjohnson/trunk/hutch-python/forks/pcdsdaq"
 source pcdsdaq_lib_setup
 export CONDA_PROMPT_MODIFIER="(${HUTCH}-${CONDA_ENVNAME})"


### PR DESCRIPTION
Cleaning up mecenv and moving MEC to the latest PCDS conda environment for Run 18. 