### PR TITLE
ENH: Add common dev area

### DIFF
--- a/mecenv
+++ b/mecenv
@@ -12,6 +12,6 @@ unset LD_LIBRARY_PATH
 source "${CONDA_BASE}/etc/profile.d/conda.sh"
 conda activate "${CONDA_ENVNAME}"
 HERE=`dirname $(readlink -f $0)`
-export PYTHONPATH="${HERE}:${HERE}/dev/devpath:/reg/neh/home/tjohnson/trunk/hutch-python/forks/pcdsdaq"
+export PYTHONPATH="${HERE}:${HERE}/dev/devpath:/reg/neh/home/tjohnson/trunk/hutch-python/forks/pcdsdaq:${HERE}/../common/dev/devpath"
 source pcdsdaq_lib_setup
 export CONDA_PROMPT_MODIFIER="(${HUTCH}-${CONDA_ENVNAME})"

--- a/set-common-dev
+++ b/set-common-dev
@@ -1,0 +1,24 @@
+#!/bin/bash
+MODULE="$1"
+if [ -z "$2" ]; then
+  IMPORT="${MODULE}"
+else
+  IMPORT="$2"
+fi
+if [ -z "$3" ]; then
+  REPO='pcdshub'
+else
+  REPO="$3"
+fi
+
+HERE=`dirname $(readlink -f $0)`
+mkdir -p "${HERE}/../common/dev/devpath"
+
+pushd "${HERE}/../common/dev"
+
+if [ ! -d "${MODULE}" ]; then
+  git clone "git@github.com:${REPO}/${MODULE}.git"
+  ln -s `readlink -f "${MODULE}/${IMPORT}"` "devpath/${IMPORT}"
+fi
+
+popd


### PR DESCRIPTION
Added support for a common development area.
This is useful for deploying or testing out packages that haven't yet been included in a new environment release. These changes have been made across all hutches.

`mecenv` change adds the new common dev area to the python path.
The order should be {hutch}/dev, {common}/dev, pcds-env

`set-common-dev` clones the desired repository in the common dev area. Remember that this will affect all hutches so be careful when using this script.