### PR TITLE
LV80 + dual laser shot

### DIFF
--- a/experiments/lv8018.py
+++ b/experiments/lv8018.py
@@ -47,12 +47,16 @@ class TimingChannel(object):
         currval = self.control_PV.get()
         self.control_PV.put(currval - relval)
 
+    def mv(self, val):
+        t0 = self.storage_PV.get()
+        self.control_PV.put(t0 - val)
+
     def get_delay(self, verbose=False):
         delay = self.control_PV.get() - self.storage_PV.get()
         if delay > 0:
-            print("X-rays arrive {} s before the optical laser".format(delay))
+            print("X-rays arrive {} s before the optical laser".format(abs(delay)))
         elif delay < 0:
-            print("X-rays arrive {} s after the optical laser".format(delay))
+            print("X-rays arrive {} s after the optical laser".format(abs(delay)))
         else: # delay is 0
             print("X-rays arrive at the same time as the optical laser")
         if verbose:
@@ -78,6 +82,11 @@ class FSTiming(object):
         newval = currval - (relval * 1e9) 
         self._channel.control_PV.put(newval)
 
+    def mv(self, val):
+        t0 = self._channel.storage_PV.get()
+        newval = t0 - (val * 1e9) 
+        self._channel.control_PV.put(newval)
+
     def get_delay(self, verbose=False):
         t0 = self._channel.storage_PV.get()
         currval = self._channel.control_PV.get()
@@ -86,9 +95,9 @@ class FSTiming(object):
         if diff == 0: 
             print("Xrays are co-timed with the optical laser")
         elif diff < 0:
-            print("Xrays arrive {0:.2f} fs before the optical laser".format(diff*1.0e6))
+            print("Xrays arrive {0:.2f} fs before the optical laser".format(abs(diff*1.0e6)))
         else:
-            print("Xrays arrive {0:.2f} fs after the optical laser".format(diff*1.0e6))
+            print("Xrays arrive {0:.2f} fs after the optical laser".format(abs(diff*1.0e6)))
 
 class NSTiming(object):
     _channels = [\
@@ -108,6 +117,10 @@ class NSTiming(object):
     def mvr(self, relval):
         for channel in self._channels:
             channel.mvr(relval)
+
+    def mv(self, val):
+        for channel in self._channels:
+            channel.mv(val)
 
     def get_delay(self, verbose=False):
         for channel in self._channels:
@@ -186,12 +199,12 @@ class User():
             self._shutters[shutter].close()
 
         # Block THz generation
-        print("Blocking THz generation...")
-        yield from bps.mv(self.thz_motor, self.thz_blocked_pos, wait=True)
-
-        # Block SPL
-        print("Blocking Short Pulse...")
-        yield from bps.mv(self.spl_motor, self.spl_blocked_pos, wait=True)
+#        print("Blocking THz generation...")
+#        yield from bps.mv(self.thz_motor, self.thz_blocked_pos, wait=True)
+#
+#        # Block SPL
+#        print("Blocking Short Pulse...")
+#        yield from bps.mv(self.spl_motor, self.spl_blocked_pos, wait=True)
 
         print("Configuring DAQ...")
 #        daq.configure(events=1, record=record)
@@ -250,13 +263,13 @@ class User():
         for shutter in self.shutters:
             self._shutters[shutter].close()
 
-        # Block THz generation
-        print("Blocking THz generation...")
-        yield from bps.mv(self.thz_motor, self.thz_blocked_pos, wait=True)
-
-        # Block SPL
-        print("Blocking Short Pulse...")
-        yield from bps.mv(self.spl_motor, self.spl_blocked_pos, wait=True)
+#        # Block THz generation
+#        print("Blocking THz generation...")
+#        yield from bps.mv(self.thz_motor, self.thz_blocked_pos, wait=True)
+#
+#        # Block SPL
+#        print("Blocking Short Pulse...")
+#        yield from bps.mv(self.spl_motor, self.spl_blocked_pos, wait=True)
 
 #        print("Configuring DAQ...")
 #        daq.configure(events=nshots, record=record)

--- a/experiments/lv8018.py
+++ b/experiments/lv8018.py
@@ -1,0 +1,428 @@
+import logging
+import bluesky.plan_stubs as bps
+from bluesky.plans import count
+import time
+
+from pcdsdevices.epics_motor import Motor
+from ophyd.pv_positioner import PVPositioner
+from ophyd.device import FormattedComponent as FCpt
+from ophyd.signal import EpicsSignal, EpicsSignalRO
+
+from mec.db import seq, daq
+from mec.db import mec_pulsepicker as pp
+from mec.db import shutter1, shutter2, shutter3, shutter4, shutter5, shutter6
+from mec.sequence import Sequence
+from mec.laser import FemtoSecondLaser, NanoSecondLaser, DualLaser
+
+logger = logging.getLogger(__name__)
+
+thz_motor = Motor('MEC:USR:MMS:25', name='thz_motor')
+spl_motor = Motor('MEC:USR:MMS:22', name='spl_motor')
+
+class TimingChannel(object):
+    def __init__(self, setpoint_PV, readback_PV, name):
+        self.control_PV = EpicsSignal(setpoint_PV) # DG/Vitara PV
+        self.storage_PV = EpicsSignal(readback_PV) # Notepad PV
+        self.name = name
+
+    def save_t0(self, val=None):
+        """
+        Set the t0 value directly, or save the current value as t0.
+        """
+        if not val: # Take current value to be t0 if not provided
+            val = self.control_PV.get()
+        self.storage_PV.put(val) # Save t0 value
+
+    def restore_t0(self):
+        """
+        Restore the t0 value from the current saved value for t0.
+        """
+        val = self.storage_PV.get()
+        self.control_PV.put(val) # write t0 value
+
+    def mvr(self, relval):
+        """
+        Move the control PV relative to it's current value.
+        """
+        currval = self.control_PV.get()
+        self.control_PV.put(currval - relval)
+
+    def get_delay(self, verbose=False):
+        delay = self.control_PV.get() - self.storage_PV.get()
+        if delay > 0:
+            print("X-rays arrive {} s before the optical laser".format(delay))
+        elif delay < 0:
+            print("X-rays arrive {} s after the optical laser".format(delay))
+        else: # delay is 0
+            print("X-rays arrive at the same time as the optical laser")
+        if verbose:
+            control_data = (self.name, self.control_PV.pvname,
+                            self.control_PV.get())
+            storage_data = (self.name, self.storage_PV.pvname,
+                            self.storage_PV.get())
+            print("{} Control PV: {}, Control Value: {}".format(*control_data))
+            print("{} Storage PV: {}, Storage Value: {}".format(*storage_data))
+
+class FSTiming(object):
+    def __init__(self):
+        self._channel = TimingChannel('LAS:FS6:VIT:FS_TGT_TIME', 'MEC:NOTE:LAS:FST0', 'FSTiming')
+
+    def save_t0(self, val=None):
+        self._channel.save_t0(val)
+
+    def restore_t0(self):
+        self._channel.restore_t0()
+
+    def mvr(self, relval):
+        currval = self._channel.control_PV.get()
+        newval = currval - (relval * 1e9) 
+        self._channel.control_PV.put(newval)
+
+    def get_delay(self, verbose=False):
+        t0 = self._channel.storage_PV.get()
+        currval = self._channel.control_PV.get()
+        diff = t0 - currval
+
+        if diff == 0: 
+            print("Xrays are co-timed with the optical laser")
+        elif diff < 0:
+            print("Xrays arrive {0:.2f} fs before the optical laser".format(diff*1.0e6))
+        else:
+            print("Xrays arrive {0:.2f} fs after the optical laser".format(diff*1.0e6))
+
+class NSTiming(object):
+    _channels = [\
+        TimingChannel('MEC:LAS:DDG:03:aDelayAO', 'MEC:NOTE:DOUBLE:41', 'chA'),
+        TimingChannel('MEC:LAS:DDG:03:cDelayAO', 'MEC:NOTE:DOUBLE:42', 'chC'),
+        TimingChannel('MEC:LAS:DDG:03:eDelayAO', 'MEC:NOTE:DOUBLE:43', 'chE'),
+        TimingChannel('MEC:LAS:DDG:03:gDelayAO', 'MEC:NOTE:DOUBLE:44', 'chG')]
+
+    def save_t0(self, val=None):
+        for channel in self._channels:
+            channel.save_t0(val)
+
+    def restore_t0(self):
+        for channel in self._channels:
+            channel.restore_t0()
+
+    def mvr(self, relval):
+        for channel in self._channels:
+            channel.mvr(relval)
+
+    def get_delay(self, verbose=False):
+        for channel in self._channels:
+            channel.get_delay(verbose=verbose)
+
+nstiming = NSTiming()
+
+fstiming = FSTiming()
+        
+def lpl_save_master_timing():
+    _bkup = [\
+        TimingChannel('MEC:LAS:DDG:03:aDelayAO', 'MEC:NOTE:DOUBLE:45', 'bkupA'),
+        TimingChannel('MEC:LAS:DDG:03:cDelayAO', 'MEC:NOTE:DOUBLE:46', 'bkupC'),
+        TimingChannel('MEC:LAS:DDG:03:eDelayAO', 'MEC:NOTE:DOUBLE:47', 'bkupE'),
+        TimingChannel('MEC:LAS:DDG:03:gDelayAO', 'MEC:NOTE:DOUBLE:48', 'bkupG')]
+
+    for channel in _bkup:
+        channel.save_t0()
+
+class User():
+    thz_blocked_pos = 10.0 
+    thz_passed_pos = 50.0  
+    spl_blocked_pos = 5.5 
+    spl_passed_pos = 2.5 
+    thz_motor = thz_motor
+    spl_motor = spl_motor
+    shutters = [1,2,3,4,5,6]
+    _shutters = {1: shutter1,
+             2: shutter2,
+             3: shutter3,
+             4: shutter4,
+             5: shutter5,
+             6: shutter6}
+
+    _seq = Sequence()
+    _sync_markers = {0.5:0, 1:1, 5:2, 10:3, 30:4, 60:5, 120:6, 360:7}
+
+    nstiming = nstiming
+
+    fstiming = fstiming
+
+    def lpl_save_master_timing(self):
+        lpl_save_master_timing()
+
+    def longpulse_shot(self, record=True, end_run=True):
+        """
+        Returns a BlueSky plan to perform a long pulse laser shot. Collects a
+        long pulse laser only shot.
+        
+        Parameters:
+        -----------
+        record : bool <default: True>
+            Flag to record the data (or not).
+
+        end_run : bool <default: True>
+            Flag to end the run after completion (or not).
+        """
+        logging.debug("Calling User.longpulse_shot with parameters:")        
+        logging.debug("record: {}".format(record))        
+        logging.debug("end_run: {}".format(end_run))
+
+        print("Closing shutters...")
+        for shutter in self.shutters:
+            self._shutters[shutter].close()
+
+        # Block THz generation
+        print("Blocking THz generation...")
+        yield from bps.mv(self.thz_motor, self.thz_blocked_pos, wait=True)
+
+        # Block SPL
+        print("Blocking Short Pulse...")
+        yield from bps.mv(self.spl_motor, self.spl_blocked_pos, wait=True)
+
+        print("Configuring DAQ...")
+        daq.configure(events=1, record=record)
+
+        print("Configuring sequencer...")
+        # Setup the pulse picker for single shots in flip flop mode
+        pp.flipflop(wait=True)
+        # Setup sequencer for requested rate
+        sync_mark = int(self._sync_markers[10])
+        seq.sync_marker.put(sync_mark)
+        seq.play_mode.put(0) # Run sequence once
+        # Setup sequence
+        self._seq.rate = 10
+        s = self._seq.opticalSequence(1, 'longpulse')
+        seq.sequence.put_seq(s)
+
+        yield from count([daq, seq], num=1)
+
+        if end_run:
+            daq.end_run()
+
+
+        print("Opening shutters...")
+        for shutter in self.shutters:
+            self._shutters[shutter].open()
+
+    def xrd_cal(self, nshots=1, record=True, end_run=True):
+        """
+        Returns a BlueSky plan to perform an XRD calibration run. Collects a
+        number of X-ray only shots.
+        
+        Parameters:
+        -----------
+        nshots : int <default: 1>
+            The number of shots that you would like to take in the run.
+
+        record : bool <default: True>
+            Flag to record the data (or not).
+
+        end_run : bool <default: True>
+            Flag to end the run after completion (or not).
+        """
+        logging.debug("Calling User.xrd_cal with parameters:")        
+        logging.debug("nshots: {}".format(nshots))        
+        logging.debug("record: {}".format(record))        
+        logging.debug("end_run: {}".format(end_run))
+
+
+        print("Closing shutters...")
+        for shutter in self.shutters:
+            self._shutters[shutter].close()
+
+        # Block THz generation
+        print("Blocking THz generation...")
+        yield from bps.mv(self.thz_motor, self.thz_blocked_pos, wait=True)
+
+        # Block SPL
+        print("Blocking Short Pulse...")
+        yield from bps.mv(self.spl_motor, self.spl_blocked_pos, wait=True)
+
+        print("Configuring DAQ...")
+        daq.configure(events=nshots, record=record)
+
+        print("Configuring sequencer...")
+        # Setup the pulse picker for single shots in flip flop mode
+        pp.flipflop(wait=True)
+        # Setup sequencer for requested rate
+        sync_mark = int(self._sync_markers[5])
+        seq.sync_marker.put(sync_mark)
+        seq.play_mode.put(1) # Run multiple times
+        seq.rep_count.put(nshots)
+        # Setup sequence
+        self._seq.rate = 5
+        s = self._seq.darkXraySequence(1)
+        seq.sequence.put_seq(s)
+
+        yield from count([daq, seq], num=1)
+
+        if end_run:
+            daq.end_run()
+
+
+        print("Opening shutters...")
+        for shutter in self.shutters:
+            self._shutters[shutter].open()
+
+    def ech_background(self, nshots=1, record=True, end_run=True):
+        """
+        Returns a BlueSky plan to perform an echelon background run. Collects a 
+        number of short pulse shots with THz generation blocked. 
+        
+        Parameters:
+        -----------
+        nshots : int <default: 1>
+            The number of shots that you would like to take in the run.
+
+        record : bool <default: True>
+            Flag to record the data (or not).
+
+        end_run : bool <default: True>
+            Flag to end the run after completion (or not).
+        """
+        logging.debug("Calling User.ech_background with parameters:")        
+        logging.debug("nshots: {}".format(nshots))        
+        logging.debug("record: {}".format(record))        
+        logging.debug("end_run: {}".format(end_run))
+
+        print("Closing shutters...")
+        for shutter in self.shutters:
+            self._shutters[shutter].close()
+
+        # Block THz generation
+        print("Blocking THz generation...")
+        yield from bps.mv(self.thz_motor, self.thz_blocked_pos, wait=True)
+
+        # Block SPL
+        print("Un-Blocking Short Pulse...")
+        yield from bps.mv(self.spl_motor, self.spl_passed_pos, wait=True)
+
+        print("Configuring DAQ...")
+        daq.configure(events=nshots, record=record)
+
+        print("Configuring sequencer...")
+        # Setup the pulse picker for single shots in flip flop mode
+        pp.flipflop(wait=True)
+        # Setup sequencer for requested rate
+        sync_mark = int(self._sync_markers[5])
+        seq.sync_marker.put(sync_mark)
+        seq.play_mode.put(1) # Run multiple times
+        seq.rep_count.put(nshots)
+        # Setup sequence
+        self._seq.rate = 5
+        s = self._seq.opticalSequence(1, 'shortpulse')
+        seq.sequence.put_seq(s)
+
+        yield from count([daq, seq], num=1)
+
+        if end_run:
+            daq.end_run()
+
+        print("Opening shutters...")
+        for shutter in self.shutters:
+            self._shutters[shutter].open()
+
+    def thz_reference(self, nshots=1, record=True, end_run=True):
+        """
+        Returns a BlueSky plan to perform an THz reference run. Collects a 
+        number of short pulse laser shots with THz generation un-blocked. 
+        
+        Parameters:
+        -----------
+        nshots : int <default: 1>
+            The number of shots that you would like to take in the run.
+
+        record : bool <default: True>
+            Flag to record the data (or not).
+
+        end_run : bool <default: True>
+            Flag to end the run after completion (or not).
+        """
+        logging.debug("Calling User.thz_reference with parameters:")        
+        logging.debug("nshots: {}".format(nshots))        
+        logging.debug("record: {}".format(record))        
+        logging.debug("end_run: {}".format(end_run))
+
+        # Un-Block THz generation
+        print("Un-Blocking THz generation...")
+        yield from bps.mv(self.thz_motor, self.thz_passed_pos, wait=True)
+
+        # Un-Block SPL
+        print("Un-Blocking Short Pulse...")
+        yield from bps.mv(self.spl_motor, self.spl_passed_pos, wait=True)
+
+        print("Configuring DAQ...")
+        daq.configure(events=nshots, record=record)
+
+        print("Configuring sequencer...")
+        # Setup the pulse picker for single shots in flip flop mode
+        pp.flipflop(wait=True)
+        # Setup sequencer for requested rate
+        sync_mark = int(self._sync_markers[5])
+        seq.sync_marker.put(sync_mark)
+        seq.play_mode.put(1) # Run multiple times
+        seq.rep_count.put(nshots)
+        # Setup sequence
+        self._seq.rate = 5
+        s = self._seq.opticalSequence(1, 'shortpulse')
+        seq.sequence.put_seq(s)
+
+        yield from count([daq, seq], num=1)
+
+        if end_run:
+            daq.end_run()
+
+        print("Opening shutters...")
+        for shutter in self.shutters:
+            self._shutters[shutter].open()
+
+    def thz_drive(self, record=True, end_run=True):
+        """
+        Returns a BlueSky plan to perform a shot with the short pulse, THz
+        generation, and long pulse drive, with the XFEL. Takes a single shot.  
+        
+        Parameters:
+        -----------
+        record : bool <default: True>
+            Flag to record the data (or not).
+
+        end_run : bool <default: True>
+            Flag to end the run after completion (or not).
+        """
+        logging.debug("Calling User.thz_drive with parameters:")        
+        logging.debug("record: {}".format(record))        
+        logging.debug("end_run: {}".format(end_run))
+
+        # Un-Block THz generation
+        print("Un-Blocking THz generation...")
+        yield from bps.mv(self.thz_motor, self.thz_passed_pos, wait=True)
+
+        # Un-Block SPL
+        print("Un-Blocking Short Pulse...")
+        yield from bps.mv(self.spl_motor, self.spl_passed_pos, wait=True)
+
+        print("Configuring DAQ...")
+        daq.configure(events=1, record=record)
+
+        print("Configuring sequencer...")
+        # Setup the pulse picker for single shots in flip flop mode
+        pp.flipflop(wait=True)
+        # Setup sequencer for requested rate
+        sync_mark = int(self._sync_markers[5])
+        seq.sync_marker.put(sync_mark)
+        seq.play_mode.put(0) # Run once
+        # Setup sequence
+        self._seq.rate = 10 
+        s = self._seq.dualDuringSequence()
+        seq.sequence.put_seq(s)
+
+        yield from count([daq, seq], num=1)
+
+        if end_run:
+            daq.end_run()
+
+        print("Opening shutters...")
+        for shutter in self.shutters:
+            self._shutters[shutter].open()

--- a/experiments/lv8018.py
+++ b/experiments/lv8018.py
@@ -130,7 +130,7 @@ def lpl_save_master_timing():
 class User():
     thz_blocked_pos = 10.0 
     thz_passed_pos = 50.0  
-    spl_blocked_pos = 5.5 
+    spl_blocked_pos = 5.94
     spl_passed_pos = 2.5 
     thz_motor = thz_motor
     spl_motor = spl_motor
@@ -152,7 +152,18 @@ class User():
     def lpl_save_master_timing(self):
         lpl_save_master_timing()
 
-    def longpulse_shot(self, record=True, end_run=True):
+    def open_shutters(self):
+        print("Opening shutters...")
+        for shutter in self.shutters:
+            self._shutters[shutter].open()
+
+    def close_shutters(self):
+        print("Closing shutters...")
+        for shutter in self.shutters:
+            self._shutters[shutter].close()
+
+#    def longpulse_shot(self, record=True, end_run=True):
+    def longpulse_shot(self, record=True):
         """
         Returns a BlueSky plan to perform a long pulse laser shot. Collects a
         long pulse laser only shot.
@@ -162,12 +173,13 @@ class User():
         record : bool <default: True>
             Flag to record the data (or not).
 
-        end_run : bool <default: True>
-            Flag to end the run after completion (or not).
         """
+#        end_run : bool <default: True>
+#            Flag to end the run after completion (or not).
+
         logging.debug("Calling User.longpulse_shot with parameters:")        
         logging.debug("record: {}".format(record))        
-        logging.debug("end_run: {}".format(end_run))
+#        logging.debug("end_run: {}".format(end_run))
 
         print("Closing shutters...")
         for shutter in self.shutters:
@@ -182,7 +194,8 @@ class User():
         yield from bps.mv(self.spl_motor, self.spl_blocked_pos, wait=True)
 
         print("Configuring DAQ...")
-        daq.configure(events=1, record=record)
+#        daq.configure(events=1, record=record)
+        daq.configure(record=record)
 
         print("Configuring sequencer...")
         # Setup the pulse picker for single shots in flip flop mode
@@ -193,20 +206,25 @@ class User():
         seq.play_mode.put(0) # Run sequence once
         # Setup sequence
         self._seq.rate = 10
-        s = self._seq.opticalSequence(1, 'longpulse')
+#        s = self._seq.opticalSequence(1, 'longpulse')
+        s = self._seq.duringSequence(1, 'longpulse')
         seq.sequence.put_seq(s)
 
-        yield from count([daq, seq], num=1)
+        print("Now run 'daq.begin_infinite()' and press 'start' on the",
+              "sequencer.")
+#        yield from count([daq, seq], num=1)
+#
+#        if end_run:
+#            time.sleep(3)
+#            daq.end_run()
+#
+#
+#        print("Opening shutters...")
+#        for shutter in self.shutters:
+#            self._shutters[shutter].open()
 
-        if end_run:
-            daq.end_run()
-
-
-        print("Opening shutters...")
-        for shutter in self.shutters:
-            self._shutters[shutter].open()
-
-    def xrd_cal(self, nshots=1, record=True, end_run=True):
+#    def xrd_cal(self, nshots=1, record=True, end_run=True):
+    def xrd_cal(self, nshots=1, record=True):
         """
         Returns a BlueSky plan to perform an XRD calibration run. Collects a
         number of X-ray only shots.
@@ -219,13 +237,13 @@ class User():
         record : bool <default: True>
             Flag to record the data (or not).
 
-        end_run : bool <default: True>
-            Flag to end the run after completion (or not).
         """
+#        end_run : bool <default: True>
+#            Flag to end the run after completion (or not).
         logging.debug("Calling User.xrd_cal with parameters:")        
         logging.debug("nshots: {}".format(nshots))        
         logging.debug("record: {}".format(record))        
-        logging.debug("end_run: {}".format(end_run))
+#        logging.debug("end_run: {}".format(end_run))
 
 
         print("Closing shutters...")
@@ -240,8 +258,9 @@ class User():
         print("Blocking Short Pulse...")
         yield from bps.mv(self.spl_motor, self.spl_blocked_pos, wait=True)
 
-        print("Configuring DAQ...")
-        daq.configure(events=nshots, record=record)
+#        print("Configuring DAQ...")
+#        daq.configure(events=nshots, record=record)
+        daq.configure(record=record)
 
         print("Configuring sequencer...")
         # Setup the pulse picker for single shots in flip flop mode
@@ -256,17 +275,21 @@ class User():
         s = self._seq.darkXraySequence(1)
         seq.sequence.put_seq(s)
 
-        yield from count([daq, seq], num=1)
+        print("Now run 'daq.begin_infinite()' and press 'start' on the",
+              "sequencer.")
+#        yield from count([daq, seq], num=1)
+#
+#        if end_run:
+#            time.sleep(3)
+#            daq.end_run()
 
-        if end_run:
-            daq.end_run()
 
+#        print("Opening shutters...")
+#        for shutter in self.shutters:
+#            self._shutters[shutter].open()
 
-        print("Opening shutters...")
-        for shutter in self.shutters:
-            self._shutters[shutter].open()
-
-    def ech_background(self, nshots=1, record=True, end_run=True):
+#    def ech_background(self, nshots=1, record=True, end_run=True):
+    def ech_background(self, nshots=1, record=True):
         """
         Returns a BlueSky plan to perform an echelon background run. Collects a 
         number of short pulse shots with THz generation blocked. 
@@ -279,13 +302,14 @@ class User():
         record : bool <default: True>
             Flag to record the data (or not).
 
-        end_run : bool <default: True>
-            Flag to end the run after completion (or not).
         """
+#        end_run : bool <default: True>
+#            Flag to end the run after completion (or not).
+
         logging.debug("Calling User.ech_background with parameters:")        
         logging.debug("nshots: {}".format(nshots))        
         logging.debug("record: {}".format(record))        
-        logging.debug("end_run: {}".format(end_run))
+#        logging.debug("end_run: {}".format(end_run))
 
         print("Closing shutters...")
         for shutter in self.shutters:
@@ -299,8 +323,9 @@ class User():
         print("Un-Blocking Short Pulse...")
         yield from bps.mv(self.spl_motor, self.spl_passed_pos, wait=True)
 
-        print("Configuring DAQ...")
-        daq.configure(events=nshots, record=record)
+#        print("Configuring DAQ...")
+#        daq.configure(events=nshots, record=record)
+        daq.configure(record=record)
 
         print("Configuring sequencer...")
         # Setup the pulse picker for single shots in flip flop mode
@@ -315,16 +340,20 @@ class User():
         s = self._seq.opticalSequence(1, 'shortpulse')
         seq.sequence.put_seq(s)
 
-        yield from count([daq, seq], num=1)
+        print("Now run 'daq.begin_infinite()' and press 'start' on the",
+              "sequencer.")
+#        yield from count([daq, seq], num=1)
+#
+#        if end_run:
+#            time.sleep(3)
+#            daq.end_run()
 
-        if end_run:
-            daq.end_run()
+#        print("Opening shutters...")
+#        for shutter in self.shutters:
+#            self._shutters[shutter].open()
 
-        print("Opening shutters...")
-        for shutter in self.shutters:
-            self._shutters[shutter].open()
-
-    def thz_reference(self, nshots=1, record=True, end_run=True):
+#    def thz_reference(self, nshots=1, record=True, end_run=True):
+    def thz_reference(self, nshots=1, record=True):
         """
         Returns a BlueSky plan to perform an THz reference run. Collects a 
         number of short pulse laser shots with THz generation un-blocked. 
@@ -336,14 +365,14 @@ class User():
 
         record : bool <default: True>
             Flag to record the data (or not).
-
-        end_run : bool <default: True>
-            Flag to end the run after completion (or not).
         """
+#        end_run : bool <default: True>
+#            Flag to end the run after completion (or not).
+
         logging.debug("Calling User.thz_reference with parameters:")        
         logging.debug("nshots: {}".format(nshots))        
         logging.debug("record: {}".format(record))        
-        logging.debug("end_run: {}".format(end_run))
+#        logging.debug("end_run: {}".format(end_run))
 
         # Un-Block THz generation
         print("Un-Blocking THz generation...")
@@ -354,7 +383,8 @@ class User():
         yield from bps.mv(self.spl_motor, self.spl_passed_pos, wait=True)
 
         print("Configuring DAQ...")
-        daq.configure(events=nshots, record=record)
+#        daq.configure(events=nshots, record=record)
+        daq.configure(record=record)
 
         print("Configuring sequencer...")
         # Setup the pulse picker for single shots in flip flop mode
@@ -369,16 +399,20 @@ class User():
         s = self._seq.opticalSequence(1, 'shortpulse')
         seq.sequence.put_seq(s)
 
-        yield from count([daq, seq], num=1)
+        print("Now run 'daq.begin_infinite()' and press 'start' on the",
+              "sequencer.")
+#        yield from count([daq, seq], num=1)
+#
+#        if end_run:
+#            time.sleep(3)
+#            daq.end_run()
+#
+#        print("Opening shutters...")
+#        for shutter in self.shutters:
+#            self._shutters[shutter].open()
 
-        if end_run:
-            daq.end_run()
-
-        print("Opening shutters...")
-        for shutter in self.shutters:
-            self._shutters[shutter].open()
-
-    def thz_drive(self, record=True, end_run=True):
+#    def thz_drive(self, record=True, end_run=True):
+    def thz_drive(self, record=True):
         """
         Returns a BlueSky plan to perform a shot with the short pulse, THz
         generation, and long pulse drive, with the XFEL. Takes a single shot.  
@@ -388,12 +422,12 @@ class User():
         record : bool <default: True>
             Flag to record the data (or not).
 
-        end_run : bool <default: True>
-            Flag to end the run after completion (or not).
         """
+#        end_run : bool <default: True>
+#            Flag to end the run after completion (or not).
         logging.debug("Calling User.thz_drive with parameters:")        
         logging.debug("record: {}".format(record))        
-        logging.debug("end_run: {}".format(end_run))
+        #logging.debug("end_run: {}".format(end_run))
 
         # Un-Block THz generation
         print("Un-Blocking THz generation...")
@@ -401,16 +435,15 @@ class User():
 
         # Un-Block SPL
         print("Un-Blocking Short Pulse...")
-        yield from bps.mv(self.spl_motor, self.spl_passed_pos, wait=True)
-
         print("Configuring DAQ...")
-        daq.configure(events=1, record=record)
+        #daq.configure(events=1, record=record)
+        daq.configure(record=record)
 
         print("Configuring sequencer...")
         # Setup the pulse picker for single shots in flip flop mode
         pp.flipflop(wait=True)
         # Setup sequencer for requested rate
-        sync_mark = int(self._sync_markers[5])
+        sync_mark = int(self._sync_markers[10])
         seq.sync_marker.put(sync_mark)
         seq.play_mode.put(0) # Run once
         # Setup sequence
@@ -418,11 +451,14 @@ class User():
         s = self._seq.dualDuringSequence()
         seq.sequence.put_seq(s)
 
-        yield from count([daq, seq], num=1)
+        print("Now run 'daq.begin_infinite()' and press 'start' on the",
+              "sequencer.")
+        #yield from count([daq, seq], num=1)
 
-        if end_run:
-            daq.end_run()
+        #if end_run:
+        #    time.sleep(3)
+        #    daq.end_run()
 
-        print("Opening shutters...")
-        for shutter in self.shutters:
-            self._shutters[shutter].open()
+        #print("Opening shutters...")
+        #for shutter in self.shutters:
+        #    self._shutters[shutter].open()

--- a/mec/beamline.py
+++ b/mec/beamline.py
@@ -51,8 +51,8 @@ with safe_load('target hexapod'):
 
 with safe_load('event sequencer'):
     from pcdsdevices.sequencer import EventSequencer
-#    seq = EventSequencer('ECS:SYS0:6', name='seq_6')
-    seq = EventSequencer('FAKE:ECS:SYS0:6', name='seq_6')
+    seq = EventSequencer('ECS:SYS0:6', name='seq_6')
+#    seq = EventSequencer('FAKE:ECS:SYS0:6', name='seq_6')
 
 #with safe_load('fake event sequencer'):
 #    from pcdsdevices.sequencer import EventSequencer

--- a/mec/laser.py
+++ b/mec/laser.py
@@ -343,7 +343,7 @@ class Laser():
         print("Configured for {} total shots.".format(total_shots))
         logging.debug("Total shots: {}".format(total_shots))
     
-        yield from bps.configure(daq, begin_sleep=2, record=record, use_l3t=use_l3t, controls=controls)
+        yield from bps.configure(daq, events=0, begin_sleep=2, record=record, use_l3t=use_l3t, controls=controls)
 
         # Add sequencer, DAQ to detectors for shots
         dets = [daq, seq]
@@ -371,7 +371,7 @@ class Laser():
             # Get number of predark shots
             shots = self._config['predark']
             logging.debug("Configuring for {} predark shots".format(shots))
-            yield from bps.configure(daq, events=shots)
+#            yield from bps.configure(daq, events=shots)
 
             # Preshot dark, so use preshot laser marker
             pre_dark_seq = self._seq.darkSequence(shots, preshot=True)
@@ -386,7 +386,7 @@ class Laser():
             # Get number of prex shots
             shots = self._config['prex']
             logging.debug("Configuring for {} prex shots".format(shots))
-            yield from bps.configure(daq, events=shots)
+#            yield from bps.configure(daq, events=shots)
 
             # Preshot x-ray only shots, so use preshot laser marker
             prex_seq = self._seq.darkXraySequence(shots, preshot=True)
@@ -401,7 +401,7 @@ class Laser():
             # Get number of preo shots
             shots = self._config['preo']
             logging.debug("Configuring for {} preo shots".format(shots))
-            yield from bps.configure(daq, events=shots)
+#            yield from bps.configure(daq, events=shots)
 
             # Optical only shot, with defined laser
             preo_seq = self._seq.opticalSequence(shots, self._config['laser'],\
@@ -417,7 +417,7 @@ class Laser():
             # Get number of during shots
             shots = self._config['during']
             logging.debug("Configuring for {} during shots".format(shots))
-            yield from bps.configure(daq, events=shots)
+#            yield from bps.configure(daq, events=shots)
 
             # During shot, with defined laser
             during_seq = self._seq.duringSequence(shots, self._config['laser'])
@@ -432,7 +432,7 @@ class Laser():
             # Get number of post optical shots
             shots = self._config['posto']
             logging.debug("Configuring for {} posto shots".format(shots))
-            yield from bps.configure(daq, events=shots)
+#            yield from bps.configure(daq, events=shots)
 
             # Optical only shot, with defined laser
             posto_seq = self._seq.opticalSequence(shots, self._config['laser'],\
@@ -448,7 +448,7 @@ class Laser():
             # Get number of postx shots
             shots = self._config['postx']
             logging.debug("Configuring for {} postx shots".format(shots))
-            yield from bps.configure(daq, events=shots)
+#            yield from bps.configure(daq, events=shots)
 
             # Postshot x-ray only shots, so use postshot laser marker
             postx_seq = self._seq.darkXraySequence(shots, preshot=False)
@@ -463,7 +463,7 @@ class Laser():
             # Get number of postdark shots
             shots = self._config['postdark']
             logging.debug("Configuring for {} postdark shots".format(shots))
-            yield from bps.configure(daq, events=shots)
+#            yield from bps.configure(daq, events=shots)
 
             # Postshot dark, so use postshot laser marker
             post_dark_seq = self._seq.darkSequence(shots, preshot=False)
@@ -848,7 +848,7 @@ class DualLaser(Laser):
         seq.sequence.put_seq(dual_seq)
 
         # Number of shots is determined by sequencer, so just trigger/read
-        print("Taking {} predark shots ... ".format(shots)
+        print("Taking {} shots shots ... ".format(shots))
         yield from bps.trigger_and_read(dets)
 
         for det in dets:
@@ -868,8 +868,7 @@ class DualLaser(Laser):
 
         use_l3t : bool
             Select whether the run will use a level 3 trigger or not. Defaults
-            to False.
-
+            to False.  
         controls : list
             List of controls devices to include values into the DAQ data stream
             as variables. All devices must have a name attribute. Defaults to

--- a/mec/sequence.py
+++ b/mec/sequence.py
@@ -350,3 +350,27 @@ class Sequence:
             
         return seq
 
+
+    def dualDuringSequence(self):
+        """
+        Setup a 'dual' during sequence ( FSL + NSL + XFEL).
+
+        Sets up a single shot. 
+        """
+        bd = int(120/self.rate) # Beam deltas per laser shot
+
+        # Setup the shot
+        eventcodes = []
+        eventcodes.append([self.EC['pulsepicker'], 2])
+        eventcodes.append([self.EC['daqreadout'], 0])
+        eventcodes.append([self.EC['longpulse', 0])
+        eventcodes.append([self.EC['shortpulse', 0])
+        if self.slowcam:
+            eventcodes.append([self.EC['slowcam'], self.slowcamdelay])
+        if self.prelasertrig > 0:
+            eventcodes.append([self.EC['prelasertrig'], self.prelasertrig])
+
+        seq = generateSequence(eventcodes, bd)
+            
+        return seq
+

--- a/mec/sequence.py
+++ b/mec/sequence.py
@@ -363,8 +363,8 @@ class Sequence:
         eventcodes = []
         eventcodes.append([self.EC['pulsepicker'], 2])
         eventcodes.append([self.EC['daqreadout'], 0])
-        eventcodes.append([self.EC['longpulse', 0])
-        eventcodes.append([self.EC['shortpulse', 0])
+        eventcodes.append([self.EC['longpulse'], 0])
+        eventcodes.append([self.EC['shortpulse'], 0])
         if self.slowcam:
             eventcodes.append([self.EC['slowcam'], self.slowcamdelay])
         if self.prelasertrig > 0:

--- a/mecenv
+++ b/mecenv
@@ -13,6 +13,7 @@ unset LD_LIBRARY_PATH
 source "${CONDA_BASE}/etc/profile.d/conda.sh"
 conda activate "${CONDA_ENVNAME}"
 HERE=`dirname $(readlink -f $0)`
-export PYTHONPATH="${HERE}:${HERE}/dev/devpath:/reg/g/pcds/pyps/apps/dev/pythonpath:${HERE}/../common/dev/devpath"
+#export PYTHONPATH="${HERE}:${HERE}/dev/devpath:/reg/g/pcds/pyps/apps/dev/pythonpath:${HERE}/../common/dev/devpath"
+export PYTHONPATH="${HERE}:${HERE}/dev/devpath:/reg/neh/home/tjohnson/trunk/hutch-python/forks/pcdsdaq:/reg/g/pcds/pyps/apps/dev/pythonpath:${HERE}/../common/dev/devpath"
 source pcdsdaq_lib_setup
 export CONDA_PROMPT_MODIFIER="(${HUTCH}-${CONDA_ENVNAME})"

--- a/mecenv
+++ b/mecenv
@@ -13,6 +13,6 @@ unset LD_LIBRARY_PATH
 source "${CONDA_BASE}/etc/profile.d/conda.sh"
 conda activate "${CONDA_ENVNAME}"
 HERE=`dirname $(readlink -f $0)`
-export PYTHONPATH="${HERE}:${HERE}/dev/devpath:/reg/g/pcds/pyps/apps/dev/pythonpath:/reg/neh/home/tjohnson/trunk/hutch-python/forks/pcdsdaq:${HERE}/../common/dev/devpath"
+export PYTHONPATH="${HERE}:${HERE}/dev/devpath:/reg/g/pcds/pyps/apps/dev/pythonpath:${HERE}/../common/dev/devpath"
 source pcdsdaq_lib_setup
 export CONDA_PROMPT_MODIFIER="(${HUTCH}-${CONDA_ENVNAME})"

--- a/mecenv
+++ b/mecenv
@@ -13,7 +13,6 @@ unset LD_LIBRARY_PATH
 source "${CONDA_BASE}/etc/profile.d/conda.sh"
 conda activate "${CONDA_ENVNAME}"
 HERE=`dirname $(readlink -f $0)`
-#export PYTHONPATH="${HERE}:${HERE}/dev/devpath:/reg/g/pcds/pyps/apps/dev/pythonpath:${HERE}/../common/dev/devpath"
-export PYTHONPATH="${HERE}:${HERE}/dev/devpath:/reg/neh/home/tjohnson/trunk/hutch-python/forks/pcdsdaq:/reg/g/pcds/pyps/apps/dev/pythonpath:${HERE}/../common/dev/devpath"
+export PYTHONPATH="${HERE}:${HERE}/dev/devpath:/reg/g/pcds/pyps/apps/dev/pythonpath:${HERE}/../common/dev/devpath"
 source pcdsdaq_lib_setup
 export CONDA_PROMPT_MODIFIER="(${HUTCH}-${CONDA_ENVNAME})"


### PR DESCRIPTION
Adding in support for taking a "dual" laser shot, as required for LV80. 

New files/changes of note:

- experiments/lv8018.py: contains experiment specific code for LV80, as well as some new timing control objects that we will want to move into a MEC specific timing module at some point before LV25.
- mec/sequence.py: added a new sequence ("dualDuringSequence") that will take a combined LPL+SPL+Xray shot. 
- mec/laser.py: Added a new dual laser class for taking a "dual" shot. Ran into some issues with the original laser scripts during testing, and eventually opted for the implementation in lv8018.py, but we should revisit this at some point after LV80. I decided to keep the dual laser class in since there's not much sense in deleting it, even if we aren't going to use it right now. 